### PR TITLE
Update`wasmedge-sdk` and readme for `object-detection-via-wasinn`

### DIFF
--- a/object-detection-via-wasinn/Cargo.toml
+++ b/object-detection-via-wasinn/Cargo.toml
@@ -4,4 +4,4 @@ name = "object-detection-via-wasinn"
 version = "0.4.0"
 
 [dependencies]
-wasmedge-sdk = { version = "0.12.0", features = ["wasi_nn"] }
+wasmedge-sdk = { version = "0.13.0", features = ["wasi_nn"] }

--- a/object-detection-via-wasinn/README.md
+++ b/object-detection-via-wasinn/README.md
@@ -12,7 +12,7 @@ Now let's build and run this example.
 
   Go to the [official Rust webpage](https://www.rust-lang.org/tools/install) and follow the instructions to install `rustup` and `Rust`.
 
-  > It is recommended to use Rust 1.69 or above in the stable channel.
+  > It is recommended to use Rust 1.73 or above in the stable channel.
 
   Then, add `wasm32-wasi` target to the Rustup toolchain:
 
@@ -28,7 +28,7 @@ Now let's build and run this example.
   # NOTICE that the installation script needs `sudo` access
 
   # install wasmedge to the directory /usr/local/
-  curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.4 -p /usr/local
+  curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v 0.13.5 -p /usr/local --plugins wasi_nn-pytorch
   ```
 
   > For users in China mainland (中国大陆地区), try the following command to install WasmEdge Runtime if failed to run the command above
@@ -36,7 +36,7 @@ Now let's build and run this example.
   > ```bash
   > # NOTICE that the installation script needs `sudo` access
   >
-  > bash install_zh.sh -v 0.13.4 -p /usr/local
+  > bash install_zh.sh -v 0.13.5 -p /usr/local
   > ```
 
 - Install `libtorch` and `WasmEdge WASI-NN PyTorch Backend`
@@ -69,10 +69,10 @@ Now let's build and run this example.
     cd /usr/local/lib/wasmedge
 
     # download and unzip WASI-NN plugin PyTorch Backend
-    wget https://github.com/WasmEdge/WasmEdge/releases/download/0.13.0/WasmEdge-plugin-wasi_nn-pytorch-0.13.0-ubuntu20.04_x86_64.tar.gz
+    wget https://github.com/WasmEdge/WasmEdge/releases/download/0.13.5/WasmEdge-plugin-wasi_nn-pytorch-0.13.5-ubuntu20.04_x86_64.tar.gz
 
     # unzip plugin
-    tar -zxf WasmEdge-plugin-wasi_nn-pytorch-0.13.0-ubuntu20.04_x86_64.tar.gz
+    tar -zxf WasmEdge-plugin-wasi_nn-pytorch-0.13.5-ubuntu20.04_x86_64.tar.gz
 
     # set WASMEDGE_PLUGIN_PATH environment variable
     export WASMEDGE_PLUGIN_PATH=/usr/local/lib/wasmedge


### PR DESCRIPTION
The `WasmEdge_FunctionInstanceGetData` usage in https://github.com/WasmEdge/wasmedge-rust-sdk/pull/84 requires `wasmedge-sdk` at `0.13.0`, also dependant on the introduction of this API from the WasmEdge runtime change in https://github.com/WasmEdge/WasmEdge/pull/2937 at 0.13.5.

README update fixes https://github.com/second-state/wasmedge-rustsdk-examples/issues/6. The missing plugin would otherwise cause:
```rust
Running `target/debug/object-detection-via-wasinn '.:.' wasmedge-wasinn-example-mobilenet-image.wasm mobilenet.pt input.jpg`
load plugin
Error: Plugin(NotFound("wasi_nn"))
```